### PR TITLE
Further caching configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ To run either metrics or training in LoCoMoSeT (see below), metrics and/or train
 
 Both kinds of config should contain:
 
-- `caches`: Contains `models`, `datasets`, `wandb`, which show where to cache HuggingFace models & datasets and wandb runs & artifacts respectively. Also contains `preprocess_cache`, which can be set to `disk`, `ram`, or `tmp` to cache preprocessed data to disk (default), memory, or a temporary directory.
+- `caches`: Contains cache locations and extra caching related arguments:
+  - `models`, `datasets`, `wandb`:  Where to cache HuggingFace models & datasets and wandb runs & artifacts respectively.
+  - `preprocess_cache`: Set to `disk`, `ram`, or `tmp` to cache preprocessed data to disk (default), memory, or a temporary directory.
+  - `tmp_dir`: Overwrites the location of the temporary directory (usually only relevant if `preprocess_cache` is `tmp`, and generally should only be set if the default tmp dir for the OS is not large enough, e.g. on Baskerville this can be set to a path in `/scratch-global` if you need more disk quota than what's available in `/tmp`).
+  - `writer_batch_size`: How many images to cache in memory before writing to disk. during preprocessing (relevant if `preprocess_cache` is `disk` or `tmp`)
 - `dataset_name`: Name of the dataset on HuggingFace
 - `dataset_args`: Contains dataset split/column selection parameters:
   - `train_split`, `val_split`: Training and validation split to use for fine-tuning
@@ -85,7 +89,7 @@ Train configs should additionally contain the following nested under `dataset_ar
 - `train_split`: Name of the data split to train on
 - `val_split`: Name of the data split to evaluate on. If the same as `train_split`, the `train_split` will itself be randomly split for training and evaluation
 
-Along with several further arguments nested under `training_args`:
+Along with any further `training_args`, which are all directly passed to HuggingFace `TrainingArguments`, for example:
 
 - `eval_steps`: Steps between each evaluation
 - `evaluation_strategy`: HuggingFace evaluation strategy

--- a/configs/top_config_rvlcdip.yaml
+++ b/configs/top_config_rvlcdip.yaml
@@ -78,7 +78,7 @@ bask:
     gpu_number: 1
     cpu_per_gpu': 36
 
-# Cache locations:
+# Cache locations and arguments:
 caches:
   datasets: /bask/projects/v/vjgo8416-locomoset/ARC-LoCoMoSeT/.cache/huggingface/datasets
   models: /bask/projects/v/vjgo8416-locomoset/ARC-LoCoMoSeT/.cache/huggingface/models
@@ -88,7 +88,13 @@ caches:
   #   - 'disk' (default) - cache preprocessed to the datasets cache dir specified above
   #   - 'ram' - cache preprocessed data in memory
   #   - 'tmp' - cache preprocessed data to a temporary directory (deleted after job completion)
-  preprocess_cache: ram
+  preprocess_cache: tmp
+  # Sets the TMPDIR environment variable (usually only relevant if preprocess_cache is tmp, and
+  # should only be set if the default TMPDIR is not large enough)
+  tmp_dir: /scratch-global/slurm-jobs/vjgo8416-locomoset
+  # How many images to cache in memory before writing to disk during preprocessing (relevant if
+  # preprocess_cache is disk or tmp)
+  writer_batch_size: 100
 
 # Training specific config -----------------------------------------------------------------
 

--- a/src/locomoset/datasets/load.py
+++ b/src/locomoset/datasets/load.py
@@ -24,6 +24,8 @@ def load_dataset(
         HuggingFace Dataset (if a split was defined) or DatasetDict (if no split was
             defined).
     """
+    print("DEBUG datasets.is_caching_enabled", datasets.is_caching_enabled())
+    print("DEBUG keep_in_memory", keep_in_memory)
     dataset = datasets.load_dataset(
         dataset_name, split=split, cache_dir=cache_dir, keep_in_memory=keep_in_memory
     )

--- a/src/locomoset/datasets/load.py
+++ b/src/locomoset/datasets/load.py
@@ -24,8 +24,6 @@ def load_dataset(
         HuggingFace Dataset (if a split was defined) or DatasetDict (if no split was
             defined).
     """
-    print("DEBUG datasets.is_caching_enabled", datasets.is_caching_enabled())
-    print("DEBUG keep_in_memory", keep_in_memory)
     dataset = datasets.load_dataset(
         dataset_name, split=split, cache_dir=cache_dir, keep_in_memory=keep_in_memory
     )

--- a/src/locomoset/datasets/preprocess.py
+++ b/src/locomoset/datasets/preprocess.py
@@ -40,11 +40,13 @@ def preprocess(
         ]
         return sample
 
+    print("DEBUG set writer_batch_size to 100")
     processed_dataset = dataset.map(
         proc_sample,
         batched=False,
         remove_columns="image",
         keep_in_memory=keep_in_memory,
+        writer_batch_size=100,
     )
     return processed_dataset.with_format("torch")
 

--- a/src/locomoset/datasets/preprocess.py
+++ b/src/locomoset/datasets/preprocess.py
@@ -1,8 +1,6 @@
 """
 Helper functions for preprocessing datasets.
 """
-import tempfile
-
 from datasets import ClassLabel, Dataset, DatasetDict
 from transformers.image_processing_utils import BaseImageProcessor
 from transformers.image_utils import load_image
@@ -161,7 +159,6 @@ def prepare_training_data(
     Returns:
         Tuple of preprocessed train and validation datasets.
     """
-    print("DEBUG tempfile.gettempdir", tempfile.gettempdir())
     dataset = encode_labels(dataset)
 
     if isinstance(dataset, DatasetDict) and len(dataset) == 1:

--- a/src/locomoset/datasets/preprocess.py
+++ b/src/locomoset/datasets/preprocess.py
@@ -7,7 +7,10 @@ from transformers.image_utils import load_image
 
 
 def preprocess(
-    dataset: Dataset, processor: BaseImageProcessor, keep_in_memory: str | None = None
+    dataset: Dataset,
+    processor: BaseImageProcessor,
+    keep_in_memory: str | None = None,
+    writer_batch_size: int | None = 1000,
 ) -> Dataset:
     """Convert an image dataset to RGB and run it through a pre-processor for
     compatibility with a model.
@@ -20,6 +23,7 @@ def preprocess(
         processor: HuggingFace trained pre-processor to use.
         keep_in_memory: Cache the dataset and any preprocessed files to RAM rather than
             disk if True.
+        writer_batch_size: How many samples to keep in RAM before writing to disk.
 
     Returns:
         Processed dataset with feature 'pixel_values' instead of 'image'.
@@ -45,7 +49,7 @@ def preprocess(
         batched=False,
         remove_columns="image",
         keep_in_memory=keep_in_memory,
-        writer_batch_size=100,
+        writer_batch_size=writer_batch_size,
     )
     return processed_dataset.with_format("torch")
 
@@ -132,6 +136,7 @@ def prepare_training_data(
     random_state: int | None = None,
     test_size: float | int | None = None,
     keep_in_memory: bool | None = None,
+    writer_batch_size: int | None = 1000,
 ) -> (Dataset, Dataset):
     """Preprocesses a dataset and splits it into train and validation sets.
 
@@ -149,6 +154,7 @@ def prepare_training_data(
             training for evaluation).
         keep_in_memory: Cache the dataset and any preprocessed files to RAM rather than
             disk if True.
+        writer_batch_size: How many samples to keep in RAM before writing to disk.
 
     Returns:
         Tuple of preprocessed train and validation datasets.
@@ -166,9 +172,15 @@ def prepare_training_data(
         val_split = "test"
 
     train_dataset = preprocess(
-        dataset[train_split], processor, keep_in_memory=keep_in_memory
+        dataset[train_split],
+        processor,
+        keep_in_memory=keep_in_memory,
+        writer_batch_size=writer_batch_size,
     )
     val_dataset = preprocess(
-        dataset[val_split], processor, keep_in_memory=keep_in_memory
+        dataset[val_split],
+        processor,
+        keep_in_memory=keep_in_memory,
+        writer_batch_size=writer_batch_size,
     )
     return train_dataset, val_dataset

--- a/src/locomoset/datasets/preprocess.py
+++ b/src/locomoset/datasets/preprocess.py
@@ -40,7 +40,6 @@ def preprocess(
         ]
         return sample
 
-    print("DEBUG set writer_batch_size to 100")
     processed_dataset = dataset.map(
         proc_sample,
         batched=False,

--- a/src/locomoset/datasets/preprocess.py
+++ b/src/locomoset/datasets/preprocess.py
@@ -1,6 +1,8 @@
 """
 Helper functions for preprocessing datasets.
 """
+import tempfile
+
 from datasets import ClassLabel, Dataset, DatasetDict
 from transformers.image_processing_utils import BaseImageProcessor
 from transformers.image_utils import load_image
@@ -159,6 +161,7 @@ def prepare_training_data(
     Returns:
         Tuple of preprocessed train and validation datasets.
     """
+    print("DEBUG tempfile.gettempdir", tempfile.gettempdir())
     dataset = encode_labels(dataset)
 
     if isinstance(dataset, DatasetDict) and len(dataset) == 1:

--- a/src/locomoset/models/train.py
+++ b/src/locomoset/models/train.py
@@ -89,12 +89,10 @@ def run_config(config: FineTuningConfig) -> Trainer:
 
     if config.caches.get("preprocess_cache") == "tmp":
         disable_caching()
-    print(
-        "DEBUG tmp_dir in config.caches and config.caches[tmp_dir] is not None",
-        "tmp_dir" in config.caches and config.caches["tmp_dir"] is not None,
-    )
+
     if "tmp_dir" in config.caches and config.caches["tmp_dir"] is not None:
-        print("DEBUG tmp_dir", config.caches["tmp_dir"])
+        # This is a workaround for overwriting the default path for tmp dirs,
+        # see https://github.com/alan-turing-institute/ARC-LoCoMoSeT/issues/93
         os.environ["TMPDIR"] = config.caches["tmp_dir"]
         tempfile.tempdir = config.caches["tmp_dir"]
 

--- a/src/locomoset/models/train.py
+++ b/src/locomoset/models/train.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from typing import Callable
 
 import evaluate
@@ -95,6 +96,7 @@ def run_config(config: FineTuningConfig) -> Trainer:
     if "tmp_dir" in config.caches and config.caches["tmp_dir"] is not None:
         print("DEBUG tmp_dir", config.caches["tmp_dir"])
         os.environ["TMPDIR"] = config.caches["tmp_dir"]
+        tempfile.tempdir = config.caches["tmp_dir"]
 
     processor = get_processor(config.model_name, cache=config.caches["datasets"])
 

--- a/src/locomoset/models/train.py
+++ b/src/locomoset/models/train.py
@@ -1,3 +1,4 @@
+import os
 from typing import Callable
 
 import evaluate
@@ -87,6 +88,8 @@ def run_config(config: FineTuningConfig) -> Trainer:
 
     if config.caches.get("preprocess_cache") == "tmp":
         disable_caching()
+    if "tmp_dir" in config.caches and config.caches["tmp_dir"] is not None:
+        os.environ["TMPDIR"] = config.caches["tmp_dir"]
 
     processor = get_processor(config.model_name, cache=config.caches["datasets"])
 
@@ -116,10 +119,12 @@ def run_config(config: FineTuningConfig) -> Trainer:
     train_dataset, val_dataset = prepare_training_data(
         dataset,
         processor,
-        train_split,
-        val_split,
-        config.random_state,
-        config.dataset_args.get("test_size"),
+        train_split=train_split,
+        val_split=val_split,
+        random_state=config.random_state,
+        test_size=config.dataset_args.get("test_size"),
+        keep_in_memory=keep_in_memory,
+        writer_batch_size=config.caches.get("writer_batch_size", 1000),
     )
     del dataset
 

--- a/src/locomoset/models/train.py
+++ b/src/locomoset/models/train.py
@@ -88,7 +88,12 @@ def run_config(config: FineTuningConfig) -> Trainer:
 
     if config.caches.get("preprocess_cache") == "tmp":
         disable_caching()
+    print(
+        "DEBUG tmp_dir in config.caches and config.caches[tmp_dir] is not None",
+        "tmp_dir" in config.caches and config.caches["tmp_dir"] is not None,
+    )
     if "tmp_dir" in config.caches and config.caches["tmp_dir"] is not None:
+        print("DEBUG tmp_dir", config.caches["tmp_dir"])
         os.environ["TMPDIR"] = config.caches["tmp_dir"]
 
     processor = get_processor(config.model_name, cache=config.caches["datasets"])


### PR DESCRIPTION
With this I managed to get a RVL CDIP training job running on the whole dataset with a single GPU (though it would take more than a week to finish with the biggest model we're using...)

- Option to change where temporary directories will be stored
- Option to change `writer_batch_size` which determines how many samples are kept in RAM before writing to disk